### PR TITLE
Add wyoming-openwakeword executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,9 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     keywords="rhasspy wyoming openwakeword",
+    entry_points={
+        'console_scripts': [
+            'wyoming-openwakeword = wyoming_openwakeword:__main__.run'
+        ]
+    },
 )

--- a/wyoming_openwakeword/__main__.py
+++ b/wyoming_openwakeword/__main__.py
@@ -119,9 +119,12 @@ async def main() -> None:
 
 # -----------------------------------------------------------------------------
 
+def run():
+    asyncio.run(main())
+
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        run()
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
This change provides an executable that will be installed into the bin/ directory of the python environment, which is simpler to start up, because the correct python instance is already implied.