### PR TITLE
Allow falling back to tensorflow

### DIFF
--- a/wyoming_openwakeword/openwakeword.py
+++ b/wyoming_openwakeword/openwakeword.py
@@ -4,7 +4,10 @@ from datetime import datetime
 from typing import Dict, List, Optional, TextIO
 
 import numpy as np
-import tflite_runtime.interpreter as tflite
+try:
+    import tflite_runtime.interpreter as tflite
+except ModuleNotFoundError:
+    import tensorflow.lite as tflite
 from wyoming.wake import Detection
 
 from .const import (


### PR DESCRIPTION
As a distro we don't have tflite packaged, but the more complete tensorflow package. It would simplify using openwakeword for us if wyoming-openwakeword would fallback to tensorflow, when tflite is unavailable.

We've been shipping this patch since we introduced wyoming-openwakeword 1.5.1 back in September 2023, and it works fine.

If you don't want this patch, that's not a problem, we'll keep it downstream.