### PR TITLE
Depend on tflite-runtime instead of tflite-runtime-nightly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-tflite-runtime-nightly
+tflite-runtime
 wyoming==1.5.3


### PR DESCRIPTION
Depending on tflite-runtime-nightly is causing issues such as #19
This is resulting in errors with wyoming-satellite installer as well (eg. https://github.com/rhasspy/wyoming-satellite/issues/157)

Hopefully this change should resolve all of these.