### PR TITLE
Specify numpy version to be older than 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tflite-runtime-nightly
 wyoming==1.5.3
+numpy<2


### PR DESCRIPTION
Fixes the issue due to the new numpy 2.0 described here
https://github.com/rhasspy/wyoming-satellite/issues/157#issuecomment-2180755652