### PR TITLE
Replace tflite-runtime with LiteRT (ai-edge-litert)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tflite-runtime
 wyoming==1.5.3
 numpy<2
+ai-edge-litert==1.3.0

--- a/wyoming_openwakeword/openwakeword.py
+++ b/wyoming_openwakeword/openwakeword.py
@@ -5,10 +5,12 @@ from typing import Dict, List, Optional, TextIO
 
 import numpy as np
 
-try:
-    import tflite_runtime.interpreter as tflite
-except ModuleNotFoundError:
-    import tensorflow.lite as tflite
+from ai_edge_litert.interpreter import Interpreter as LiteRTInterpreter
+
+class TFLiteWrapper:
+    Interpreter = LiteRTInterpreter
+
+tflite = TFLiteWrapper()
 from wyoming.wake import Detection
 
 from .const import (


### PR DESCRIPTION
- Remove tflite-runtime completely in favor of LiteRT
- Use ai-edge-litert==1.3.0 which works on all platforms including macOS ARM (pinned due to https://github.com/google-ai-edge/LiteRT/issues/2836)
- Simplify import logic - no more fallbacks needed
- LiteRT is the official replacement for TensorFlow Lite

This enables OpenWakeWord to run on Apple Silicon Macs (M1/M2) and other platforms that don't have tflite-runtime packages available.

Tested on macOS with Apple Silicon and Linux x86_64.


Context: I created [agent-cli](https://github.com/basnijholt/agent-cli) that relies on `wyoming-openwakeword`
> `agent-cli` is a collection of **_local-first_**, AI-powered command-line agents that run entirely on your machine.
It provides a suite of powerful tools for voice and text interaction, designed for privacy, offline capability, and seamless integration with system-wide hotkeys and workflows.