### PR TITLE
Add docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker run -it -p 10400:10400 -v /path/to/custom/models:/custom rhasspy/wyoming-
     --custom-model-dir /custom
 ```
 
-## Docker Compose
+### Docker Compose
 ```
 services:
   wyoming-openwakeword:

--- a/README.md
+++ b/README.md
@@ -47,4 +47,24 @@ docker run -it -p 10400:10400 -v /path/to/custom/models:/custom rhasspy/wyoming-
     --custom-model-dir /custom
 ```
 
+## Docker Compose
+```
+services:
+  wyoming-openwakeword:
+    image: rhasspy/wyoming-openwakeword
+    container_name: wyoming-openwakeword
+    command:
+      - --preload-model
+      - 'ok_nabu' # Change this to a supported wake word. Supported wake words include ok_nabu, hey_jarvis, alexa, hey_mycroft and hey_rhasspy.
+      # Uncomment the below lines to use a custom wake word. You can find custom wake words at https://github.com/fwartner/home-assistant-wakewords-collection.
+      # - --custom-model-dir
+      # - /custom/en/wake_word
+    # volumes:
+      # - /path/to/wake/words:/custom:ro
+    ports:
+      - 10400:10400
+    restart: always
+
+```
+
 [Source](https://github.com/rhasspy/wyoming-addons/tree/master/openwakeword)


### PR DESCRIPTION
This PR adds a docker-compose file to the readme to allow running the container easier, instead on relying on `docker run` commands.

Please let me know if I need to touch up some things.