### PR TITLE
Expose entrypoint as wyoming-openwakeword script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
 [project.urls]
 "Source Code" = "http://github.com/rhasspy/wyoming-openwakeword"
 
+[project.scripts]
+wyoming-openwakeword = "wyoming_openwakeword.__main__:run"
+
 [tool.setuptools]
 platforms = ["any"]
 zip-safe  = false


### PR DESCRIPTION
This is so that when installing we'll have `wyoming-openwakeword` executable in the PATH.